### PR TITLE
fix: add a comma in a function call that cause error

### DIFF
--- a/examples/Kniwwelino_Hardwaretest/Kniwwelino_Hardwaretest.ino
+++ b/examples/Kniwwelino_Hardwaretest/Kniwwelino_Hardwaretest.ino
@@ -20,7 +20,7 @@ void setup() {
   Serial.println("Kniwwelino Hardware Test Sketch");
   Serial.println("-----------------------------------------------");
 
-  Kniwwelino.begin("hardwaretest" false, false, false); // Wifi=off, Fastboot=off
+  Kniwwelino.begin("hardwaretest", false, false, false); // Wifi=off, Fastboot=off
 
   pinMode(D0, INPUT);
   pinMode(D5, INPUT);


### PR DESCRIPTION
I caught a little error in the hardware test exemple that cause a error. This was easy to fix but it's my first contribution!