### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,7 +19,7 @@ getIP	KEYWORD2
 getMAC	KEYWORD2
 sleep	KEYWORD2
 loop	KEYWORD2
-isConnected KEYWORD2
+isConnected	KEYWORD2
 
 PINsetEffect	KEYWORD2
 PINclear	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords