### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=For using the KniwwelinoLib you need to install additional Libraries a
 category=Device Control
 url=https://github.com/list-luxembourg/KniwwelinoLib
 architectures=esp8266
+depends=Adafruit GFX Library, Adafruit NeoPixel, MQTT, WiFiManager, Time, TimeAlarms, Timezone


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

NOTE: I did not add the ArduinoJson dependency because the Arduino Library Manager dependency system is currently only capable of installing the newest version of each dependency and this library is not compatible with the 6.x.x versions of ArduinoJson. Once this library is updated to be compatible with the modern ArduinoJson library, that dependency should be added to the depends field as well.